### PR TITLE
Provide converted repository URL for SSH URLs

### DIFF
--- a/src/TfsUrlParser.Tests/RepositoryDescriptionTests.cs
+++ b/src/TfsUrlParser.Tests/RepositoryDescriptionTests.cs
@@ -35,123 +35,147 @@
             "defaultcollection",
             @"http://myserver:8080/tfs/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"http://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"http://tfs.myserver/defaultcollection/myproject/_git/myrepository",
             @"http://tfs.myserver/",
             "defaultcollection",
             @"http://tfs.myserver/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"http://tfs.myserver/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"http://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository",
             @"http://mytenant.visualstudio.com/",
             "defaultcollection",
             @"http://mytenant.visualstudio.com/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"http://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"http://tfs.foo.com/foo/foo/_git/foo",
             @"http://tfs.foo.com/",
             "foo",
             @"http://tfs.foo.com/foo",
             "foo",
-            "foo")]
+            "foo",
+            @"http://tfs.foo.com/foo/foo/_git/foo")]
         [InlineData(
             @"http://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository/somethingelse",
             @"http://mytenant.visualstudio.com/",
             "defaultcollection",
             @"http://mytenant.visualstudio.com/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"http://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository/somethingelse")]
         [InlineData(
             @"https://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository",
             @"https://myserver:8080/",
             "defaultcollection",
             @"https://myserver:8080/tfs/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"https://tfs.myserver/defaultcollection/myproject/_git/myrepository",
             @"https://tfs.myserver/",
             "defaultcollection",
             @"https://tfs.myserver/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://tfs.myserver/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"https://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository",
             @"https://mytenant.visualstudio.com/",
             "defaultcollection",
             @"https://mytenant.visualstudio.com/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"https://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository/somethingelse",
             @"https://mytenant.visualstudio.com/",
             "defaultcollection",
             @"https://mytenant.visualstudio.com/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository/somethingelse")]
         [InlineData(
             @"https://tfs.foo.com/foo/foo/_git/foo",
             @"https://tfs.foo.com/",
             "foo",
             @"https://tfs.foo.com/foo",
             "foo",
-            "foo")]
+            "foo",
+            @"https://tfs.foo.com/foo/foo/_git/foo")]
         [InlineData(
             @"ssh://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository",
             @"ssh://myserver:8080/",
             "defaultcollection",
             @"https://myserver:8080/tfs/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"ssh://tfs.myserver/defaultcollection/myproject/_git/myrepository",
             @"ssh://tfs.myserver/",
             "defaultcollection",
             @"https://tfs.myserver/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://tfs.myserver/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"ssh://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository",
             @"ssh://mytenant.visualstudio.com/",
             "defaultcollection",
             @"https://mytenant.visualstudio.com/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository")]
         [InlineData(
             @"ssh://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository/somethingelse",
             @"ssh://mytenant.visualstudio.com/",
             "defaultcollection",
             @"https://mytenant.visualstudio.com/defaultcollection",
             "myproject",
-            "myrepository")]
+            "myrepository",
+            @"https://mytenant.visualstudio.com/defaultcollection/myproject/_git/myrepository/somethingelse")]
         [InlineData(
             @"ssh://tfs.foo.com/foo/foo/_git/foo",
             @"ssh://tfs.foo.com/",
             "foo",
             @"https://tfs.foo.com/foo",
             "foo",
-            "foo")]
+            "foo",
+            @"https://tfs.foo.com/foo/foo/_git/foo")]
         [InlineData(
             @"ssh://foo:bar@myserver:8080/tfs/defaultcollection/myproject/_git/myrepository",
             @"ssh://myserver:8080/",
             "defaultcollection",
             @"https://myserver:8080/tfs/defaultcollection",
             "myproject",
-            "myrepository")]
-        public void Should_Parse_Repo_Url(string repoUrl, string serverUrl, string collectionName, string collectionurl, string projectName, string repositoryName)
+            "myrepository",
+            @"https://myserver:8080/tfs/defaultcollection/myproject/_git/myrepository")]
+        public void Should_Parse_Repo_Url(
+            string repoUrl,
+            string serverUrl,
+            string collectionName,
+            string collectionurl,
+            string projectName,
+            string repositoryName,
+            string repositoryUrl)
         {
             // Given / When
             var repositoryDescription = new RepositoryDescription(new Uri(repoUrl));
 
             // Then
-            repositoryDescription.ServerUrl.ToString().ShouldBe(serverUrl);
+            repositoryDescription.ServerUrl.ShouldBe(new Uri(serverUrl));
             repositoryDescription.CollectionName.ShouldBe(collectionName);
             repositoryDescription.CollectionUrl.ShouldBe(new Uri(collectionurl));
             repositoryDescription.ProjectName.ShouldBe(projectName);
             repositoryDescription.RepositoryName.ShouldBe(repositoryName);
+            repositoryDescription.RepositoryUrl.ShouldBe(new Uri(repositoryUrl));
         }
     }
 }

--- a/src/TfsUrlParser/RepositoryDescription.cs
+++ b/src/TfsUrlParser/RepositoryDescription.cs
@@ -22,7 +22,9 @@
                 throw new ArgumentNullException(nameof(repoUrl));
             }
 
-            var repoUrlString = ConvertToSupportedUriScheme(repoUrl).ToString();
+            this.RepositoryUrl = ConvertToSupportedUriScheme(repoUrl);
+            var repoUrlString = this.RepositoryUrl.ToString();
+
             var gitSeparator = new[] { "/_git/" };
             var splitPath = repoUrl.AbsolutePath.Split(gitSeparator, StringSplitOptions.None);
             if (splitPath.Length < 2)
@@ -73,6 +75,12 @@
         /// Gets the name of the Git repository.
         /// </summary>
         public string RepositoryName { get; private set; }
+
+        /// <summary>
+        /// Gets the URL of the Git repository.
+        /// URLs using SSH scheme are converted to HTTPS.
+        /// </summary>
+        public Uri RepositoryUrl { get; private set; }
 
         /// <summary>
         /// Converts the repository URL to a supported scheme if possible.


### PR DESCRIPTION
Provide repository URL. For SSH URLs this is the URL converted to HTTPS and without any credentials.

Fixes #11 