### PR TITLE
(GH-40) Disable documentation for tasks

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -11,7 +11,8 @@ BuildParameters.SetParameters(
     repositoryName: "TfsUrlParser",
     appVeyorAccountName: "BBTSoftwareAG",
     shouldPublishMyGet: false,
-    shouldRunCodecov: false);
+    shouldRunCodecov: false,
+    shouldDeployGraphDocumentation: false);
 
 BuildParameters.PrintParameters(Context);
 


### PR DESCRIPTION
Disable documentation for tasks of the build script in the documentation site

Fixes #40 