### PR TITLE
Enable all TFS URL's

### DIFF
--- a/src/TfsUrlParser.Tests/RepositoryDescriptionTests.cs
+++ b/src/TfsUrlParser.Tests/RepositoryDescriptionTests.cs
@@ -8,9 +8,6 @@
     {
         [Theory]
         [InlineData(
-            @"http://myserver:8080/tfs/defaultcollection/myproject/",
-            "No valid Git repository URL.")]
-        [InlineData(
             @"http://myserver:8080/tfs/defaultcollection/myproject/_git",
             "No valid Git repository URL.")]
         [InlineData(
@@ -25,6 +22,7 @@
             var result = Record.Exception(() => new RepositoryDescription(new Uri(repoUrl)));
 
             // Then
+
             result.IsUriFormatExceptionException(expectedMessage);
         }
 
@@ -192,6 +190,117 @@
             repositoryDescription.ProjectName.ShouldBe(projectName);
             repositoryDescription.RepositoryName.ShouldBe(repositoryName);
             repositoryDescription.RepositoryUrl.ShouldBe(new Uri(repositoryUrl));
+            repositoryDescription.IsRepository.ShouldBe(true);
         }
+
+        [Theory]
+        [InlineData(
+           @"http://myserver:8080/tfs/defaultcollection/myproject/",
+           @"http://myserver:8080/",
+           "defaultcollection",
+           @"http://myserver:8080/tfs/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"http://tfs.myserver/defaultcollection/myproject/",
+           @"http://tfs.myserver/",
+           "defaultcollection",
+           @"http://tfs.myserver/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"http://mytenant.visualstudio.com/defaultcollection/myproject/",
+           @"http://mytenant.visualstudio.com/",
+           "defaultcollection",
+           @"http://mytenant.visualstudio.com/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"http://tfs.foo.com/foo/foo",
+           @"http://tfs.foo.com/",
+           "foo",
+           @"http://tfs.foo.com/foo",
+           "foo")]
+        [InlineData(
+           @"https://myserver:8080/tfs/defaultcollection/myproject/",
+           @"https://myserver:8080/",
+           "defaultcollection",
+           @"https://myserver:8080/tfs/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"https://tfs.myserver/defaultcollection/myproject/",
+           @"https://tfs.myserver/",
+           "defaultcollection",
+           @"https://tfs.myserver/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"https://mytenant.visualstudio.com/defaultcollection/myproject/",
+           @"https://mytenant.visualstudio.com/",
+           "defaultcollection",
+           @"https://mytenant.visualstudio.com/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"https://tfs.foo.com/foo/foo/",
+           @"https://tfs.foo.com/",
+           "foo",
+           @"https://tfs.foo.com/foo",
+           "foo")]
+        [InlineData(
+           @"ssh://myserver:8080/tfs/defaultcollection/myproject/",
+           @"ssh://myserver:8080/",
+           "defaultcollection",
+           @"https://myserver:8080/tfs/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"ssh://tfs.myserver/defaultcollection/myproject/",
+           @"ssh://tfs.myserver/",
+           "defaultcollection",
+           @"https://tfs.myserver/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"ssh://mytenant.visualstudio.com/defaultcollection/myproject/",
+           @"ssh://mytenant.visualstudio.com/",
+           "defaultcollection",
+           @"https://mytenant.visualstudio.com/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"ssh://tfs.foo.com/foo/foo/",
+           @"ssh://tfs.foo.com/",
+           "foo",
+           @"https://tfs.foo.com/foo",
+           "foo")]
+        [InlineData(
+           @"ssh://foo:bar@myserver:8080/tfs/defaultcollection/myproject/",
+           @"ssh://myserver:8080/",
+           "defaultcollection",
+           @"https://myserver:8080/tfs/defaultcollection",
+           "myproject")]
+        [InlineData(
+           @"https://myorganization@dev.azure.com/myorganization/myproject/",
+           @"https://myorganization@dev.azure.com/",
+           "myorganization",
+           @"https://myorganization@dev.azure.com/myorganization",
+           "myproject")]
+        [InlineData(
+           @"https://myorganization.visualstudio.com/myproject/",
+           @"https://myorganization.visualstudio.com/",
+           "DefaultCollection",
+           @"https://myorganization.visualstudio.com",
+           "myproject")]
+        public void Should_Parse_NonRepo_Url(
+           string repoUrl,
+           string serverUrl,
+           string collectionName,
+           string collectionurl,
+           string projectName)
+        {
+            // Given / When
+            var repositoryDescription = new RepositoryDescription(new Uri(repoUrl));
+
+            // Then
+            repositoryDescription.ServerUrl.ShouldBe(new Uri(serverUrl));
+            repositoryDescription.CollectionName.ShouldBe(collectionName);
+            repositoryDescription.CollectionUrl.ShouldBe(new Uri(collectionurl));
+            repositoryDescription.ProjectName.ShouldBe(projectName);
+            repositoryDescription.IsRepository.ShouldBe(false);
+        }
+
     }
 }

--- a/src/TfsUrlParser/RepositoryDescription.cs
+++ b/src/TfsUrlParser/RepositoryDescription.cs
@@ -28,9 +28,17 @@
 
             var gitSeparator = new[] { "/_git/" };
             var splitPath = repoUrl.AbsolutePath.Split(gitSeparator, StringSplitOptions.None);
-            if (splitPath.Length < 2)
+            if (repoUrl.ToString().Contains("_git"))
             {
-                throw new UriFormatException("No valid Git repository URL.");
+                this.IsRepository = true;
+                if (splitPath.Length < 2)
+                {
+                    throw new UriFormatException("No valid Git repository URL.");
+                }
+
+            } else
+            {
+                this.IsRepository = false;
             }
 
             this.ServerUrl = new Uri(repoUrl.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped));
@@ -56,11 +64,13 @@
             {
                 throw new UriFormatException("No valid Git repository URL containing default collection and project name.");
             }
-
-            var splitLastPart = splitPath[1].Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-
             this.ProjectName = splitFirstPart.Last();
-            this.RepositoryName = splitLastPart.First();
+
+            if (this.IsRepository)
+            {
+                var splitLastPart = splitPath[1].Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                this.RepositoryName = splitLastPart.First();
+            }
         }
 
         /// <summary>
@@ -93,6 +103,11 @@
         /// URLs using SSH scheme are converted to HTTPS.
         /// </summary>
         public Uri RepositoryUrl { get; private set; }
+
+        /// <summary>
+        /// Get a value that indicates if this is a Git Repo or another TFS URL.
+        /// </summary>
+        public bool IsRepository { get; private set; }
 
         /// <summary>
         /// Converts the repository URL to a supported scheme if possible.


### PR DESCRIPTION
Update both code and tests to enable use with all TFS URL's not just Repositories. This better matches the name and implied function of the tool.

Note: I'm not happy with line 31, and it may need the original coder to analyze intent at this point to validate this works.

```
 var gitSeparator = new[] { "/_git/" };
 var splitPath = repoUrl.AbsolutePath.Split(gitSeparator, StringSplitOptions.None);
 if (repoUrl.ToString().Contains("_git"))
 {
     this.IsRepository = true;
     if (splitPath.Length < 2)
     {
         throw new UriFormatException("No valid Git repository URL.");
     }

 } else
 {
     this.IsRepository = false;
 }
```
All tests pass! New tests added for non-repo TFS URL's
